### PR TITLE
Se elimina la opción de pago con PayPal en la creación de sesiones de…

### DIFF
--- a/src/pages/api/create-checkout-session.js
+++ b/src/pages/api/create-checkout-session.js
@@ -51,7 +51,7 @@ export default async function handler(req, res) {
 
       // Crear sesión de checkout en Stripe
       const session = await stripe.checkout.sessions.create({
-        payment_method_types: ["card", "paypal"],
+        payment_method_types: ["card" ],//"paypal"
         line_items: [
           {
             price: priceId,


### PR DESCRIPTION
… checkout en Stripe, manteniendo únicamente el método de pago con tarjeta.